### PR TITLE
Run CI on Github Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: push
+
+jobs:
+  ts-standard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install
+      - run: npm run lint

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,37 @@
+name: Test & Build
+
+on: push
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        node-version:
+          - 12
+          - 14
+          - 16
+        architecture:
+          - x64
+    name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm install
+      - run: npm run build


### PR DESCRIPTION
This PR adds two GitHub Action workflows, one running the code linter and the other one running tests and the build. It uses a similar matrix setup for multiple node as well as OS versions as proposed in #2.

The test & build are coupled, the build runs after the test. The linter however is decoupled and runs in parallel, which improves the output in the GitHub UI and also lets the tests & build pass with linter errors still present, which gives us a bit more flexibility.

I _do_ think that the linter should run error-free, and in the future we may decide to make that a hard requirement, but for now I think the flexibility is good.