### PR TITLE
autocomplete: reject with custom APIError

### DIFF
--- a/src/api/autocomplete/result.ts
+++ b/src/api/autocomplete/result.ts
@@ -1,13 +1,10 @@
+import { RateLimit } from '../../ratelimit'
+
 // An autocomplete request promise resolves with a Result, which contains
 // the data from the API, rate limiting info, and whether or not it should be discarded
 // if it was returned out of order
 export interface Result {
   features?: any // TODO: define this
   discard?: boolean
-  rateLimit?: {
-    delaySecond: number
-    limitSecond: number
-    remainingSecond: number
-    usedSecond: number
-  }
+  rateLimit?: RateLimit
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,31 @@
+import { RateLimit } from './ratelimit'
+
+type errorType = (
+  // Pelias error
+  'GeocodingError' |
+
+  // Rate limiter errors
+  'KeyError' |
+  'ExpiredKeyError' |
+  'DisabledKeyError' |
+  'QpdExceededError' |
+  'QpsExceededError' |
+  'GatewayTimeout' |
+  'GatewayError'
+)
+
+export class APIError extends Error {
+  readonly type: errorType
+  readonly statusCode: number
+  readonly messages: string[]
+  readonly rateLimit: RateLimit
+
+  constructor (type: errorType, statusCode: number, rateLimit: RateLimit, ...messages: string[]) {
+    super(messages.join('. '))
+
+    this.type = type
+    this.statusCode = statusCode
+    this.rateLimit = rateLimit
+    this.messages = messages
+  }
+}

--- a/src/ratelimit.ts
+++ b/src/ratelimit.ts
@@ -1,0 +1,6 @@
+export interface RateLimit {
+  delaySecond: number
+  limitSecond: number
+  remainingSecond: number
+  usedSecond: number
+}


### PR DESCRIPTION
Promises should reject an Error, so this commit updates the error
handling to reject with a custom `APIError`, that contains all the error
information.

Handling the error itself looks / is a bit messy as the API response format is different depending on whether the error came from the rate limiter or pelias itself. This could be improved on in the future.

In case the response status code is not OK (not 200 range) but we can’t extract error information from the response, we throw a generalized error that contains the full response body.