### PR TITLE
fix: params: exclude '' (empty string)

### DIFF
--- a/src/api/autocomplete/params.test.ts
+++ b/src/api/autocomplete/params.test.ts
@@ -1,10 +1,10 @@
 import { Params, createQuery } from './params'
 
-test('paramsToQuery excludes empty fields', () => {
+test('createQuery excludes empty fields', () => {
   const params: Params = {
     lang: 'de',
     layers: undefined,
-    sources: undefined
+    sources: []
   }
 
   expect(createQuery('ge-abcabccbacbacbac', 'berlin', params)).toStrictEqual({

--- a/src/api/autocomplete/params.ts
+++ b/src/api/autocomplete/params.ts
@@ -68,6 +68,6 @@ export const createQuery = (apiKey: string, text: string, params: Params = {}): 
     'boundary.rect.max_lon': params.boundary?.rect?.maxLon?.toString()
   }
 
-  // don’t return empty values (null & undefined) as to not have ?size=undefined in the actual URL query
-  return Object.fromEntries(Object.entries(q).filter(([_, v]) => v != null)) as Record<string, string>
+  // don’t return empty values (null, undefined, '') as to not have ?size=undefined or empty values in the actual URL query
+  return Object.fromEntries(Object.entries(q).filter(([_, v]) => v != null && v !== '')) as Record<string, string>
 }


### PR DESCRIPTION
fix https://github.com/geocodeearth/autocomplete-element/issues/20

Previously only `null` & `undefined` were excluded, this PR also excludes `''` (empty string) so that a URL does not include `&layers=` if an empty array of layers is passed in.